### PR TITLE
json_gen: Remove shader entries when destroyed

### DIFF
--- a/layersvt/vulkan_json_layer.hpp
+++ b/layersvt/vulkan_json_layer.hpp
@@ -253,6 +253,11 @@ class PipelineData {
         m_shaderInfoMap.insert(std::make_pair(*m, s));
     }
 
+    void deleteShaderModuleInfo(VkShaderModule m)
+    {
+        m_shaderInfoMap.erase(m);
+    }
+
     void setSamplerInfo(const VkSamplerCreateInfo* pCreateInfo, VkSampler* pSampler)
     {
         if (pCreateInfo == nullptr || pSampler == nullptr) {

--- a/scripts/json_gen_generator.py
+++ b/scripts/json_gen_generator.py
@@ -270,6 +270,9 @@ JSON_INTERCEPT_API = {
     'vkCreateShaderModule':
         'vk_json::s_pipe.setShaderModuleInfo(pCreateInfo, pShaderModule);'
     ,
+    'vkDestroyShaderModule':
+        'vk_json::s_pipe.deleteShaderModuleInfo(shaderModule);'
+    ,
     'vkCreateGraphicsPipelines':
         'vk_json::s_pipe.objResInfo.graphicsPipelineRequestCount += createInfoCount;\n'
 		'\tvk_json::s_pipe.dumpGraphicsPipeline(device, createInfoCount, pCreateInfos, pPipelines);'


### PR DESCRIPTION
In the json_gen layer, we have a map that stores a key/value pair for the compiled shaders. The map needs to be updated when a shader module is destroyed.