### PR TITLE
Fix issue with short module names

### DIFF
--- a/layersvt/vulkan_json_layer.hpp
+++ b/layersvt/vulkan_json_layer.hpp
@@ -905,11 +905,12 @@ class PipelineData {
         char* p = m_exeName + (strnlen(m_exeName, MAX_NAME_SIZE) - 1);
         int writePos = 0;
 
-        while (*p-- != '.')
-            ;
-        while (*p != '\\') m_exeName[writePos++] = *p--;
+        while (*p != '.')
+            --p;
+        while (*p != '\\')
+            --p;
+        for (++p; *p != '.'; ++p) m_exeName[writePos++] = *p;
         m_exeName[writePos] = 0;
-        _strrev(m_exeName);
 #endif
 
 #ifdef __linux__


### PR DESCRIPTION
Fix for _WIN32 part of getProcessName() operating on directory names shorter than process name (f.e. "C:\test\vksc_sample_program.exe").